### PR TITLE
Ventor: change location and remove Twitter

### DIFF
--- a/people.json
+++ b/people.json
@@ -387,10 +387,9 @@
   },
   {
     "nick": "Ventor",
-    "coordinates": [50.969337, 7.044285],
+    "coordinates": [50.814427, 7.151012],
     "links": {
       "GitHub": "https://github.com/flymia",
-      "Twitter": "https://twitter.com/OfficialVentor"
     }
   },
   {

--- a/people.json
+++ b/people.json
@@ -389,7 +389,7 @@
     "nick": "Ventor",
     "coordinates": [50.814427, 7.151012],
     "links": {
-      "GitHub": "https://github.com/flymia",
+      "GitHub": "https://github.com/flymia"
     }
   },
   {


### PR DESCRIPTION
This moves my location, since it changed and removes my Twitter link, since I don't have an account anymore.